### PR TITLE
Support for separate environments for status results - K8s drop-down selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 export CROSS_CLOUD_CI_ENV="development"
 
+export DASHBOARD_API_HOST_PORT="devapi.cncf.ci"
+
+export CROSS_PROJECT_REF="staging"
+export CROSS_CLOUD_REF="master"
+
+export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/master/cross-cloud.yml"
 export CROSS_CLOUD_CONFIG_URL="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/master/cross-cloud.yml"
+
 #export GITLAB_CI_YML=$CROSS_CLOUD_CONFIG_URL
 
 #export GITLAB_API_URL="https://gitlab.dev.cncf.ci/api/v4"

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -40,8 +40,8 @@ module CrossCloudCi
         # gitlab_base_url="https://dev.vulk.co:4002/api"
         # cross_cloud_yml="https://raw.githubusercontent.com/crosscloudci/cncf-configuration/project-details-36/cross-cloud.yml"
         cross_cloud_yml="https://raw.githubusercontent.com/crosscloudci/cncf-configuration/master/cross-cloud.yml"
-        cross_cloud_ref="master"
-        cross_project_ref="master"
+        cross_cloud_ref="integration"
+        cross_project_ref="integration"
         dashboard_api_host_port="devapi.cncf.ci"
       end
 

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -127,9 +127,33 @@ module CrossCloudCI
           end
         end
 
+        job = jobs.select {|j| j["name"] == "compile-aufs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than compile-aufs or compile-overlayfs
+          status ||= job.first["status"]
+        end
+
+        job = jobs.select {|j| j["name"] == "compile-overlayfs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than compile-aufs or compile-overlayfs
+          status ||= job.first["status"]
+        end
+
         job = jobs.select {|j| j["name"] == "container"}
         unless job.empty? || job.first["status"] == "created"
           status = job.first["status"]
+        end
+
+        job = jobs.select {|j| j["name"] == "container-aufs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than container-aufs or container-overlayfs
+          status ||= job.first["status"]
+        end
+
+        job = jobs.select {|j| j["name"] == "container-overlayfs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than container-aufs or container-overlayfs
+          status ||= job.first["status"]
         end
 
         status

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -58,18 +58,18 @@ module CrossCloudCI
 
 
         # TODO: add global default
-        trigger_variables[:ARCH] = options[:arch] ||= "amd64"
+        arch = options[:arch] || "amd64"
+        trigger_variables[:ARCH] = arch
 
         @logger.info "options[:arch] #{options[:arch]}"
 
         @logger.info "trigger_variables[:ARCH] #{trigger_variables[:ARCH]}"
 
-        arch = trigger_variables[:ARCH]
 
         # TODO: Lookup arch support for each project.  
         # NOTE: Only supporting k8s for arm 
-        if project_name != "kubernetes" and options[:arch] != "amd64"
-            @logger.info "[Build] No #{options[:arch]} support for #{project_name}"
+        if project_name != "kubernetes" and arch != "amd64"
+            @logger.info "[Build] No #{arch} support for #{project_name}"
             return
         end
 

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -154,7 +154,8 @@ module CrossCloudCI
             ref = @config[:projects][name][release_key_name]
 
             # TODO: check for arch support on the provider?
-            arch_types = ["amd64", "arm64"]
+            #arch_types = ["amd64", "arm64"]
+            arch_types = ["amd64"]
 
             arch_types.each do |machine_arch|
               options[:arch] = machine_arch

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -437,7 +437,6 @@ module CrossCloudCI
         cross_cloud_id = project_id_by_name("cross-cloud")
         cross_cloud_api_token = @config[:gitlab][:pipeline]["cross-cloud"][:api_token]
 
-
         deployment_env = @provisionings.select {|p| p[:pipeline_id] == target_provision_id}.first
 
         if deployment_env.nil?
@@ -446,13 +445,11 @@ module CrossCloudCI
 
         kubernetes_release_type = "stable"
 
-        deployment_env[:target_project_ref].each do |ref|
-          case ref
-          when "master"
-            kubernetes_release_type = "head"
-          else
-            kubernetes_release_type = "stable"
-          end
+        case deployment_env[:target_project_ref]
+        when "master"
+          kubernetes_release_type = "head"
+        else
+          kubernetes_release_type = "stable"
         end
 
         trigger_variables[:KUBERNETES_RELEASE_TYPE] = kubernetes_release_type


### PR DESCRIPTION
# cncf.ci release v2.2.0

**Status Repo API client changes:**

- support provisioning multiple k8s envs and pass more details for env
- support deploying the same project to multiple clusters (1 to many)
- initial support for multiple machine arch

Issues:
- crosscloudci/crosscloudci#114
- vulk/cncf_ci#29