### PR TITLE
Enable Arm64 support for K8s as a test environment

### DIFF
--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -127,9 +127,33 @@ module CrossCloudCI
           end
         end
 
+        job = jobs.select {|j| j["name"] == "compile-aufs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than compile-aufs or compile-overlayfs
+          status ||= job.first["status"]
+        end
+
+        job = jobs.select {|j| j["name"] == "compile-overlayfs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than compile-aufs or compile-overlayfs
+          status ||= job.first["status"]
+        end
+
         job = jobs.select {|j| j["name"] == "container"}
         unless job.empty? || job.first["status"] == "created"
           status = job.first["status"]
+        end
+
+        job = jobs.select {|j| j["name"] == "container-aufs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than container-aufs or container-overlayfs
+          status ||= job.first["status"]
+        end
+
+        job = jobs.select {|j| j["name"] == "container-overlayfs"}
+        unless job.empty? || job.first["status"] == "created"
+          # compile is higher precendent than container-aufs or container-overlayfs
+          status ||= job.first["status"]
         end
 
         status


### PR DESCRIPTION
Added support for building and provisioning K8s arm in as a test environment.

Dependency:
- https://github.com/crosscloudci/ci_status_repository/pull/23

Issue:
- https://github.com/crosscloudci/crosscloudci/issues/126
- vulk/cncf_ci#129