### PR TITLE
refactor, cli support and cleanup of k8s head sync

### DIFF
--- a/bin/crosscloudci_trigger.rb
+++ b/bin/crosscloudci_trigger.rb
@@ -122,6 +122,13 @@ def provision_clouds
   @tc.provision_clouds
 end
 
+def sync_k8s_nightly_build
+  default_connect unless @tc
+  @tc.sync_k8s_nightly_build
+end
+
+
+
 def build_projects
   default_connect unless @tc
   @tc.build_projects

--- a/lib/crosscloudci/trigger_client.rb
+++ b/lib/crosscloudci/trigger_client.rb
@@ -40,11 +40,14 @@ module CrossCloudCi
       end
     end
 
+    def sync_k8s_nightly_build
+        @ciservice.sync_k8s_nightly_build
+    end
+
     def load_previous_builds
       # Load previous build data
       @ciservice.builds = @data_store.transaction { @data_store.fetch(:builds, @ciservice.builds) }
     end
-
 
     def provision_clouds
       @data_store.transaction do

--- a/scripts/sync-gitlab-kubernetes.sh
+++ b/scripts/sync-gitlab-kubernetes.sh
@@ -30,12 +30,17 @@ else
     echo "Clone successful"
 fi
 
+if [ -z "$2" ] ; then
+  K8S_COMMIT=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt)
+else
+  K8S_COMMIT="$2"
+fi
+
 pushd "$builddir"
 git remote add github https://github.com/kubernetes/kubernetes.git
 git fetch github -a
 git pull github master
-K8S_NIGHTLY=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt)
-git reset ${K8S_NIGHTLY#*+}
+git reset ${K8S_COMMIT#*+}
 git push --force --all
 git push --tags --force
 


### PR DESCRIPTION
Updates:
- Support calling sync_k8s_nightly_build from trigger client CLI
- Use Faraday for retrieving release
- Support passing any sha for syncing to internal library function call
- Support passing any sha to shell script for syncing
- refactored to use smaller building block method calls

Testing:
- Manually ran trigger client against cidev

issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265