### PR TITLE
promoting nightly build sync to dev.cncf.ci

### DIFF
--- a/bin/crosscloudci_trigger.rb
+++ b/bin/crosscloudci_trigger.rb
@@ -122,6 +122,13 @@ def provision_clouds
   @tc.provision_clouds
 end
 
+def sync_k8s_nightly_build
+  default_connect unless @tc
+  @tc.sync_k8s_nightly_build
+end
+
+
+
 def build_projects
   default_connect unless @tc
   @tc.build_projects

--- a/lib/crosscloudci/trigger_client.rb
+++ b/lib/crosscloudci/trigger_client.rb
@@ -40,11 +40,14 @@ module CrossCloudCi
       end
     end
 
+    def sync_k8s_nightly_build
+        @ciservice.sync_k8s_nightly_build
+    end
+
     def load_previous_builds
       # Load previous build data
       @ciservice.builds = @data_store.transaction { @data_store.fetch(:builds, @ciservice.builds) }
     end
-
 
     def provision_clouds
       @data_store.transaction do

--- a/scripts/sync-gitlab-kubernetes.sh
+++ b/scripts/sync-gitlab-kubernetes.sh
@@ -30,12 +30,17 @@ else
     echo "Clone successful"
 fi
 
+if [ -z "$2" ] ; then
+  K8S_COMMIT=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt)
+else
+  K8S_COMMIT="$2"
+fi
+
 pushd "$builddir"
 git remote add github https://github.com/kubernetes/kubernetes.git
 git fetch github -a
 git pull github master
-K8S_NIGHTLY=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt)
-git reset ${K8S_NIGHTLY#*+}
+git reset ${K8S_COMMIT#*+}
 git push --force --all
 git push --tags --force
 

--- a/scripts/sync-gitlab-kubernetes.sh
+++ b/scripts/sync-gitlab-kubernetes.sh
@@ -1,17 +1,39 @@
 #!/bin/bash
 
-git clone git@${1}:kubernetes/kubernetes.git /tmp/k8s
-cd /tmp/k8s
-echo "code: $?"
-if [[ $? -ne 0]]; then
-    echo 'Git clone failed'
-    exit 1
-else
-    continue
+if [ -z "$1" ]; then
+  echo "usage: $0 <git_server>"
+  exit 1
 fi
+
+TMPWORKDIR=$(mktemp -d -t k8s_build-XXXXXXX)
+repodir="kubernetes"
+builddir="$TMPWORKDIR/$repodir"
+
+function cleanup {
+  if [ -d "$TMPWORKDIR" ]; then
+    cd $TMPWORKDIR
+    [[ -d "$repodir" ]] && rm -rf $repodir
+    cd ..
+    rmdir $TMPWORKDIR
+  fi
+}
+
+echo "Working directory $builddir"
+set -x
+
+git clone git@${1}:kubernetes/kubernetes.git "$builddir"
+
+if [ $? -ne 0 -o ! -d "$builddir" ]; then
+    echo "Git clone failed to $builddir"
+    exit 1
+fi
+
+pushd "$builddir"
 git remote add github https://github.com/kubernetes/kubernetes.git
 git fetch github -a
 git pull github master
 K8S_NIGHTLY=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt)
 git reset ${K8S_NIGHTLY#*+}
 git push --force
+popd
+set +x


### PR DESCRIPTION
## Description

Added support for syncing [latest k8s ci-cross release/commit](https://storage.googleapis.com/kubernetes-release-dev/ci-cross/latest.txt) with gitlab k8s repo.

status repo and dashboard show correct commit from Gitlab as expected

Force pushing the commit to the gitlab k8s fork ensures the correct commit is used.

issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265


## Motivation and Context

Gitlab does not support creating a pipeline for a specific commit.

cncf.ci Status repository uses the commit from the Gitlab pipeline for updating dashboard.



## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.