### PR TITLE
BUGFIX: Prometheus builds(staging)

### DIFF
--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -235,6 +235,13 @@ module CrossCloudCI
             arch_types.each do |machine_arch|
               options[:arch] = machine_arch
 
+              # Prom builds will clash if they run at the same time due to the names being based on the timestamp.
+              # See https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198
+              if project_name == "prometheus"
+                puts 'Starting prometheus build delay'
+                sleep 3
+              end
+
               puts "Calling build_project(#{project_id}, #{ref}, #{options})"
               #self.build_project(project_id, api_token, ref, options)
               self.build_project(project_id, ref, options)


### PR DESCRIPTION
## Description
Fixes Prometheus build failures when multiple build pipelines get created in a short time frame.


## Motivation and Context

Prometheus builds will clash if they run at the same time due to the names being based on the timestamp.
See:
https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198



## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.