### PR TITLE
BUGFIX: Prometheus builds & K8s repo sync(production)

### DIFF
--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -235,6 +235,13 @@ module CrossCloudCI
             arch_types.each do |machine_arch|
               options[:arch] = machine_arch
 
+              # Prom builds will clash if they run at the same time due to the names being based on the timestamp.
+              # See https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198
+              if project_name == "prometheus"
+                puts 'Starting prometheus build delay'
+                sleep 3
+              end
+
               puts "Calling build_project(#{project_id}, #{ref}, #{options})"
               #self.build_project(project_id, api_token, ref, options)
               self.build_project(project_id, ref, options)

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -209,19 +209,19 @@ module CrossCloudCI
 
           @logger.debug "setting project id"
           project_id =  all_gitlab_projects.select {|agp| agp["name"].downcase == name}.first["id"]
+          project_name = project_name_by_id(project_id)
 
+          if project_name == "kubernetes"
+            @logger.debug "Syncing nightly build for #{project_name} HEAD release and pushing up all tags"
+            # mirror off in gitlab.   
+            sync_k8s_nightly_build
+          end
+          
           ["stable_ref", "head_ref"].each do |release_key_name|
             #next if name == "kubernetes" and release_key_name == "head_ref"
             ref = @config[:projects][name][release_key_name]
 
-            project_name = project_name_by_id(project_id)
             # @logger.debug "project name #{project_name}"
-
-            if project_name == "kubernetes"
-              @logger.debug "Syncing nightly build for #{project_name} HEAD release and pushing up all tags"
-              # mirror off in gitlab.   
-              sync_k8s_nightly_build
-            end
 
             # TODO: check for arch support on the provider?
             arch_types = @config[:projects][project_name]["arch"]

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -237,7 +237,7 @@ module CrossCloudCI
 
               # Prom builds will clash if they run at the same time due to the names being based on the timestamp.
               # See https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198
-              if project_name == "prometheus" && options[:arch] == "amd64"
+              if project_name == "prometheus"
                 puts 'Starting prometheus build delay'
                 sleep 15
               end

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -239,7 +239,7 @@ module CrossCloudCI
               # See https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198
               if project_name == "prometheus"
                 puts 'Starting prometheus build delay'
-                sleep 15
+                sleep 120
               end
 
               puts "Calling build_project(#{project_id}, #{ref}, #{options})"

--- a/lib/crosscloudci/ciservice_client/client.rb
+++ b/lib/crosscloudci/ciservice_client/client.rb
@@ -237,9 +237,9 @@ module CrossCloudCI
 
               # Prom builds will clash if they run at the same time due to the names being based on the timestamp.
               # See https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198
-              if project_name == "prometheus"
+              if project_name == "prometheus" && options[:arch] == "amd64"
                 puts 'Starting prometheus build delay'
-                sleep 3
+                sleep 15
               end
 
               puts "Calling build_project(#{project_id}, #{ref}, #{options})"


### PR DESCRIPTION
## Description
1. Fixes Prometheus build failures when multiple build pipelines get created in a short time frame.

2. Fixes bug where we sync the K8s repo more than once.


## Motivation and Context

1. Prometheus builds will clash if they run at the same time due to the names being based on the timestamp.
See:
https://github.com/prometheus/promu/blob/d629dfcdec49387b42164f3fe6dad353f922557e/cmd/crossbuild.go#L198

2. Currently, we sync the K8s repo for stable, head, x86 and arm, we only need to do this once.

## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.