### PR TITLE
add vitess to environment.rb in production

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -105,6 +105,9 @@ module CrossCloudCi
             "jaeger" => {
               :api_token => ENV["GITLAB_JAEGER_TOKEN"]
             },
+            "vitess" => {
+              :api_token => ENV["GITLAB_VITESS_TOKEN"]
+            },
           }
         }
       }


### PR DESCRIPTION
## Description
1. Fixing Vitess Sync on Production

Issues:
- https://github.com/crosscloudci/cncf-configuration/pull/161

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Browser tested on staging.cncf.ci
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.