### PR TITLE
reenable etcd in staging

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -105,6 +105,9 @@ module CrossCloudCi
             "jaeger" => {
               :api_token => ENV["GITLAB_JAEGER_TOKEN"]
             },
+            "etcd" => {
+              :api_token => ENV["GITLAB_ETCD_TOKEN"]
+            },
             "vitess" => {
               :api_token => ENV["GITLAB_VITESS_TOKEN"]
             },


### PR DESCRIPTION
Revert "Merge branch 'master' of github.com:crosscloudci/crosscloudci-trigger"

This reverts commit 245632e1caaf1ca5aef0ea2f96585dcaf67b5697, reversing
changes made to 9b83c0f78cbf261c83ba87f149b4fe82010f4b4e.


----

## Description
1. enables etcd

Issues:
- crosscloudci/crosscloudci#209

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [x] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Browser tested on staging.cncf.ci
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.